### PR TITLE
feat(removeHTML): replacing the use of while and innerText with textContent

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,12 +5,7 @@ var div = doc.createElement('div');
 
 function removeHTML(htmlString) {
     div.innerHTML = htmlString;
-    var elements = div.querySelectorAll('*')
-    while (elements.length) {
-        div.innerHTML = div.innerText;
-        elements = div.querySelectorAll('*');
-    }
-    return div.innerText;
+    return div.textContent;
 }
 
 function escapeHTML(htmlString) {


### PR DESCRIPTION
Hey @nolimitdev thanks for the lib its awesome.

i am using it, and a realize i have a little trouble with it at a unit text, the return of `removeHTML` was always undefined, while debugging i looked at you code and saw you perform a while loop to take the inner text of the children elements.

I'd like to suggest to change this approach and use [textContent](https://developer.mozilla.org/pt-BR/docs/Web/API/Node/textContent) instead. With textContent, which is fully supported and native, no worries on this, we avoid the use of the loop, and it with inside the unit test the result is the code skipped the tags.

Basically it do the same as your code, faster because we don't need the loop and works perfectly with the unit test.

I have done a jsbin to show the both code working, is available [here](https://jsbin.com/rukiyuloci/edit?js,console).

